### PR TITLE
Integrate User List page with server through queries

### DIFF
--- a/src/components/user-list.tsx
+++ b/src/components/user-list.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UserType } from '../queries/user-list-query';
 
 interface UserListProps {
-  users: UserType[] | undefined;
+  users?: UserType[];
 }
 
 export const UserList = ({ users }: UserListProps): React.ReactElement => {

--- a/src/components/user-list.tsx
+++ b/src/components/user-list.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { UserType } from '../pages/user-list-page';
+import { UserType } from '../queries/user-list-query';
 
 interface UserListProps {
-  users: UserType[];
+  users: UserType[] | undefined;
 }
 
 export const UserList = ({ users }: UserListProps): React.ReactElement => {
   return (
     <ul>
-      {users.map((user) => {
+      {users?.map((user) => {
         return (
-          <li key={user.name}>
+          <li key={user.id}>
             {user.name} - {user.email}
           </li>
         );

--- a/src/components/user-list.tsx
+++ b/src/components/user-list.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { UserType } from '../queries/user-list-query';
+import { User } from '../queries/user-list-query';
 
 interface UserListProps {
-  users?: UserType[];
+  users?: User[];
 }
 
 export const UserList = ({ users }: UserListProps): React.ReactElement => {

--- a/src/mutations/login-mutation.ts
+++ b/src/mutations/login-mutation.ts
@@ -1,14 +1,14 @@
 import { gql } from '@apollo/client';
 
-type UserType = {
+interface User {
   id: string;
   name: string;
-};
+}
 
-export type LoginType = {
+export interface LoginData {
   token: string;
-  user: UserType;
-};
+  user: User;
+}
 
 export const loginMutation = gql`
   mutation LoginMutation($email: String!, $password: String!) {

--- a/src/pages/user-list-page.tsx
+++ b/src/pages/user-list-page.tsx
@@ -1,39 +1,12 @@
-import React, { Fragment } from 'react';
+import { useQuery } from '@apollo/client';
+import React from 'react';
 import { UserList } from '../components/user-list';
-
-export type UserType = {
-  id: string;
-  name: string;
-  email: string;
-};
+import { userListQuery, UserListQueryDataType } from '../queries/user-list-query';
 
 export const UserListPage = (): React.ReactElement => {
-  const usersMockData: UserType[] = [
-    {
-      id: '1',
-      name: 'Grayson Nunez',
-      email: 'grayson.nunez@email.com',
-    },
-    {
-      id: '2',
-      name: 'Brendon Palmer',
-      email: 'brendon.palmer@email.com',
-    },
-    {
-      id: '3',
-      name: 'Shannon Reyes',
-      email: 'shannon.reyes@email.com',
-    },
-    {
-      id: '4',
-      name: 'Sydney Sherman',
-      email: 'sydney.sherman@email.com',
-    },
-  ];
+  const { loading, error, data } = useQuery<UserListQueryDataType>(userListQuery);
 
-  return (
-    <Fragment>
-      <UserList users={usersMockData} />
-    </Fragment>
-  );
+  const content = loading ? <p>Loading...</p> : <UserList users={data?.users.nodes} />;
+
+  return error ? <p>Error: {error.message}</p> : content;
 };

--- a/src/pages/user-list-page.tsx
+++ b/src/pages/user-list-page.tsx
@@ -1,10 +1,10 @@
 import { useQuery } from '@apollo/client';
 import React from 'react';
 import { UserList } from '../components/user-list';
-import { userListQuery, UserListQueryDataType } from '../queries/user-list-query';
+import { userListQuery, UserListQueryData } from '../queries/user-list-query';
 
 export const UserListPage = (): React.ReactElement => {
-  const { loading, error, data } = useQuery<UserListQueryDataType>(userListQuery);
+  const { loading, error, data } = useQuery<UserListQueryData>(userListQuery);
 
   const content = loading ? <p>Loading...</p> : <UserList users={data?.users.nodes} />;
 

--- a/src/queries/user-list-query.ts
+++ b/src/queries/user-list-query.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+
+export type UserType = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+export type UserListQueryDataType = {
+  users: {
+    nodes: UserType[];
+  };
+};
+
+export const userListQuery = gql`
+  query UserListQuery {
+    users {
+      nodes {
+        id
+        name
+        email
+      }
+    }
+  }
+`;

--- a/src/queries/user-list-query.ts
+++ b/src/queries/user-list-query.ts
@@ -1,16 +1,16 @@
 import { gql } from '@apollo/client';
 
-export type UserType = {
+export interface User {
   id: string;
   name: string;
   email: string;
-};
+}
 
-export type UserListQueryDataType = {
+export interface UserListQueryData {
   users: {
-    nodes: UserType[];
+    nodes: User[];
   };
-};
+}
 
 export const userListQuery = gql`
   query UserListQuery {


### PR DESCRIPTION
Esse PR cria a query UserListQuery para pegar os primeiros 20 usuários e mostrar na página de User List.

Para que a query seja executada com sucesso, deve-se primeiro logar com pela tela de login (`localhost:3000/login`) para se obter o token de autenticação.

<img width="529" alt="Screenshot 2023-05-10 at 12 48 59" src="https://github.com/indigotech/onboard-andre-nishimura/assets/80173402/80f44410-e6cd-49d4-ba52-a7a28d939772">
