### PR TITLE
Integrate add user page with create user mutation

### DIFF
--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -29,7 +29,11 @@ export const Pagination = ({
       return '...';
     }
     return (
-      <button onClick={() => setCurrentPage(page)} style={currentPage === page ? { backgroundColor: 'lightGray' } : {}}>
+      <button
+        key={page}
+        onClick={() => setCurrentPage(page)}
+        style={currentPage === page ? { backgroundColor: 'lightGray' } : {}}
+      >
         {page + 1}
       </button>
     );

--- a/src/mutations/create-user-mutation.ts
+++ b/src/mutations/create-user-mutation.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const createUserMutation = gql`
+  mutation CreateUserMutation($data: UserInput!) {
+    createUser(data: $data) {
+      id
+      name
+    }
+  }
+`;

--- a/src/pages/user-list-page.tsx
+++ b/src/pages/user-list-page.tsx
@@ -17,6 +17,7 @@ export const UserListPage = (): React.ReactElement => {
       offset: paginationOffset,
       limit: PAGE_LIMIT,
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const count = data?.users.count;


### PR DESCRIPTION
Esse PR usa a `createUser` mutation na página para adicionar usuários. 

Ao criar o usuário de forma bem sucedida, a página é redirecionada para a lista de usuários, que por sua vez apresenta-a de forma atualizada com o usuário adicionado.